### PR TITLE
Remove printf

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -97,7 +97,6 @@
                           response-maker)
   (define handler/keys/response-maker (request->handler/keys/response-maker request))
   (begin
-    (printf (url->string (request-uri request)))
     (cond
       [handler/keys/response-maker (render/handler (car handler/keys/response-maker)
                                                    request


### PR DESCRIPTION
Not sure if this is intentionally left in or not.

```
$ racket -f server.rkt 
`^C/api/game.json/api/game.json/api/game.json
```
